### PR TITLE
Change module declaration in "index.d.ts" to "gatsby-plugin-react-intl"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'gatsby-plugin-intl' {
+declare module 'gatsby-plugin-react-intl' {
   import * as gatsby from 'gatsby';
   import React from 'react';
 


### PR DESCRIPTION
Fixes "Cannot resolve symbol..." error in JetBrains IDEs.