### PR TITLE
fix: exclude unnecessary country-specific locales from bundle

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -21,7 +21,7 @@ exports.onCreateWebpackConfig = ({ actions, plugins }, pluginOptions) => {
   if (!languages.includes(defaultLanguage)) {
     languages.push(defaultLanguage)
   }
-  const regex = new RegExp(languages.map(l => l.split("-")[0]).join("|"))
+  const regex = new RegExp("(" + languages.map(l => l.split("-")[0]).join("|") + ")$")
   actions.setWebpackConfig({
     resolve: { fallback: { path: require.resolve("path-browserify") } },
     plugins: [


### PR DESCRIPTION
The original fix for excluding unnecessary locales from the final bundle (https://github.com/wiziple/gatsby-plugin-intl/pull/84) did not exclude country-specific locales if you only specified a generic one. So if you specify `de` in `gatsby-config.js`, the plugin would include `de-DE`, `de-AT`, `de-CH`, etc., still creating massive bundle sizes that the fix was intended to prevent. This new fix modifies the regex to make sure that the locale is at the end of the package name, thus filtering out the country packages unless they are explicitly specified by the user.

**Before:**

<img width="1102" alt="CleanShot 2021-06-25 at 14 17 57@2x" src="https://user-images.githubusercontent.com/5282190/123424575-50723b00-d5c1-11eb-99ba-6efb9b537f8f.png">

**After:**

<img width="1025" alt="CleanShot 2021-06-25 at 14 29 47@2x" src="https://user-images.githubusercontent.com/5282190/123424985-d4c4be00-d5c1-11eb-9fd7-72a8344fd0e9.png">

