### PR TITLE
Keep location-hash when redirecting on language-detection

### DIFF
--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -62,7 +62,7 @@ export default ({ element, props }, pluginOptions) => {
   let isRedirect = redirect && !routed
 
   if (isRedirect) {
-    const { search } = location
+    const { search, hash } = location
 
     // Skip build, Browsers only
     if (typeof window !== "undefined") {
@@ -86,7 +86,7 @@ export default ({ element, props }, pluginOptions) => {
 
       if (isRedirect) {
         const queryParams = search || ""
-        const newUrl = `/${detected}${originalPath}${queryParams}`
+        const newUrl = `/${detected}${originalPath}${queryParams}${hash}`
         window.localStorage.setItem("gatsby-intl-language", detected)
 
         navigate(newUrl, {


### PR DESCRIPTION
Right now the location-hash is eliminated when redirecting to a language specific site. This makes it unnecessary complicated to preserve an anchor. This PR aims to keep it when redirecting 😄 